### PR TITLE
Allow parties in Bo5 2v2 queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ WARNING! Deploying a stack locally can currently cost up to $10/mo. This is prim
         PLAYER_ELOS_TABLE=tm-mm-bot-player-elos-dev-<account-id>
         MATCH_RESULTS_TABLE=tm-mm-bot-match-results-dev-<account-id>
         MATCH_QUEUES_TABLE=tm-mm-bot-match-queues-dev-<account-id>
+        MATCHES_PLAYED_TABLE=tm-mm-bot-matches-played-dev-<account-id>
         LEADERBOARDS_TABLE=tm-mm-bot-leaderboards-dev-<account-id>
         RANKS_TABLE=tm-mm-bot-ranks-dev-<account-id>
         LEADERBOARD_RANKS_TABLE=tm-mm-bot-leaderboard-ranks-dev-<account-id>
@@ -51,10 +52,13 @@ WARNING! Deploying a stack locally can currently cost up to $10/mo. This is prim
             "UBI_AUTHS": ["Basic <user:pass base64>"],
             "DISCORD_BOT_TOKEN": "<token>",
             "PASTES_IO_LOGIN": "<username>",
-            "PASTES_IO_PASSWORD": "<password>"
+            "PASTES_IO_PASSWORD": "<password>",
+            "PASTEFY_LOGIN": "<username>",
+            "PASTEFY_PASSWORD": "<password>"
         }
     ```
-    For the username and password, use what you sign in with for Ubisoft, and enter it into [this website](https://www.base64decode.org/), making sure you switch to *encode* mode. For example, if you had username "my" and password "pass", type in "my:pass" and it would return "bXk6cGFzcw==", so you would set `"UBI_AUTHS": ["Basic bXk6cGFzcw=="]`. 
+    For the username and password, use what you sign in with for Ubisoft, and enter it into [this website](https://www.base64decode.org/), making sure you switch to *encode* mode. For example, if you had username "my" and password "pass", type in "my:pass" and it would return "bXk6cGFzcw==", so you would set `"UBI_AUTHS": ["Basic bXk6cGFzcw=="]`. Currently the pastefy server is hosted by Matrix/skiff. You will need to
+    contact them for credentials!
 
 8. Go to S3 and upload `secrets.json` to the bucket `tm-mm-bot-secrets-dev-<account_id>` at the root directory. 
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ WARNING! Deploying a stack locally can currently cost up to $10/mo. This is prim
             "PASTEFY_PASSWORD": "<password>"
         }
     ```
-    For the username and password, use what you sign in with for Ubisoft, and enter it into [this website](https://www.base64decode.org/), making sure you switch to *encode* mode. For example, if you had username "my" and password "pass", type in "my:pass" and it would return "bXk6cGFzcw==", so you would set `"UBI_AUTHS": ["Basic bXk6cGFzcw=="]`. Currently the pastefy server is hosted by Matrix/skiff. You will need to
-    contact them for credentials!
+    For the username and password, use what you sign in with for Ubisoft, and enter it into [this website](https://www.base64decode.org/), making sure you switch to *encode* mode. For example, if you had username "my" and password "pass", type in "my:pass" and it would return "bXk6cGFzcw==", so you would set `"UBI_AUTHS": ["Basic bXk6cGFzcw=="]`. Currently the pastefy server is hosted by Matrix/skiff. You will need to contact them for credentials!
 
 8. Go to S3 and upload `secrets.json` to the bucket `tm-mm-bot-secrets-dev-<account_id>` at the root directory. 
 

--- a/bin/tm_open_match_making_bot.ts
+++ b/bin/tm_open_match_making_bot.ts
@@ -67,10 +67,6 @@ if (process.env.STAGE == 'dev') {
     env: env,
     terminationProtection: true,
   })
-  new ReadOnlyAccessStack(app, 'TmOpenMatchMakingBotStack-ReadOnlyAccess-prod', {
-    env: env,
-    terminationProtection: true,
-  })
 } else {
   throw new Error(`Unsupported stage, must be one of "dev" or "prod", received ${process.env.STAGE}`)
 }

--- a/bin/tm_open_match_making_bot.ts
+++ b/bin/tm_open_match_making_bot.ts
@@ -67,11 +67,6 @@ if (process.env.STAGE == 'dev') {
     env: env,
     terminationProtection: true,
   })
-  new ElasticIpStack(app, 'TmOpenMatchMakingBotStack-ElasticIp-prod', {
-    env: env,
-    stage: 'prod',
-    terminationProtection: true,
-  })
   new ReadOnlyAccessStack(app, 'TmOpenMatchMakingBotStack-ReadOnlyAccess-prod', {
     env: env,
     terminationProtection: true,

--- a/lib/mm-bot/src/matchmaking/match_queues/match_persistence.py
+++ b/lib/mm-bot/src/matchmaking/match_queues/match_persistence.py
@@ -3,7 +3,6 @@ from typing import List
 
 from aws.dynamodb import DynamoDbManager
 from matchmaking.constants import NUM_1v1v1v1_PLAYERS
-from matchmaking.match_queues.enum import QueueType
 from matchmaking.matches.active_match import ActiveMatch
 from matchmaking.matches.team_2v2 import Team2v2, Teams2v2
 from models.persisted_match import PersistedMatch
@@ -40,7 +39,7 @@ def active_match_from_persisted_match(persisted_match: PersistedMatch) -> Active
         raise LookupError(f"Could not find queue for {persisted_match.queue_id}")
 
     player_profiles = None
-    if queue.type == QueueType.Queue2v2:
+    if queue.type.is_2v2():
         event_teams = get_event_teams(event_id)
 
         team_a_p1_tmacc = event_teams[0].players[0].account_id

--- a/lib/mm-bot/src/views/match_queue.py
+++ b/lib/mm-bot/src/views/match_queue.py
@@ -13,7 +13,6 @@ from cogs.party_manager import get_party_manager
 from discord import TextChannel, ui
 from discord.ext import commands, tasks
 from helpers import get_guild, get_ping_channel, get_rank_for_player
-from matchmaking.match_queues.enum import QueueType
 from matchmaking.matches.active_match import ActiveMatch
 from models.leaderboard_rank import LeaderboardRank
 from models.player_profile import PlayerProfile
@@ -113,7 +112,7 @@ class MatchQueueView(ui.View):
                 return
 
             # If this is a solo queue, do not allow player to join
-            if queue.queue.type != QueueType.Queue2v2:
+            if not queue.queue.type.is_2v2():
                 await interaction.response.send_message(
                     "This queue does not allowed partied players. Use /unparty first!",
                     ephemeral=True,


### PR DESCRIPTION
- Allow parties in Bo5 2v2 queues
- Use is_2v2 when checking persisted matches instead of 2v2 queue type
- Update Pastefy info in readme