### PR TITLE
chore: Reduce bot intents to minimum set

### DIFF
--- a/lib/mm-bot/src/main.py
+++ b/lib/mm-bot/src/main.py
@@ -16,9 +16,16 @@ from plugin.server import PluginServer
 # Define bot
 class DiscordBot(Bot):
     def __init__(self) -> None:
+        # Define minimum required intents for matchmaking bot
+        intents = Intents.default()
+        intents.guilds = True  # Required for guild/channel/role access
+        intents.guild_messages = True  # Required for sending messages
+        intents.message_content = False  # Not needed - using slash commands only
+        intents.members = True  # Required for member role management
+
         super().__init__(
             command_prefix="/",
-            intents=Intents.all(),
+            intents=intents,
         )
         self.is_shutdown = False
 


### PR DESCRIPTION
The VPC costs about $3.60 per month, which is influenced by network traffic. We can reduce this by reducing intents. Tested by running a solo queue locally, checked pressing buttons on leaderboard, and performing slash commands like /profile. 