### PR TITLE
Plugin Party System

### DIFF
--- a/lib/mm-bot/src/cogs/party_manager.py
+++ b/lib/mm-bot/src/cogs/party_manager.py
@@ -15,6 +15,7 @@ from matchmaking.party.constants import (
 )
 from matchmaking.party.party_request import PartyRequest
 from matchmaking.party.request_status import PartyRequestStatus
+from matchmaking.mm_event_bus import MatchmakingManagerEventBus
 from models.player_profile import PlayerProfile
 from views.party_request import PartyRequestView
 
@@ -27,6 +28,7 @@ class PartyManager(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.s3_manager = S3ClientManager()
+        self.mm_event_bus = MatchmakingManagerEventBus()
 
         self.active_parties: List[ActiveParty] = []
 
@@ -85,11 +87,24 @@ class PartyManager(commands.Cog):
             view=view,
         )
 
+        self.mm_event_bus.add_new_party_request(requester, [accepter])
+
         logging.info(f"Party request sent for {active_party}.")
 
         self.outstanding_party_request_messages[active_party] = PartyRequest(
             message, view
         )
+
+    async def remove_outstanding_party_request(self, party: ActiveParty) -> None:
+        party_request = self.outstanding_party_request_messages[party]
+        await safe_delete_message(party_request.message)
+        self.outstanding_party_request_messages.pop(party)
+        return
+
+    async def add_accepted_party_request(self, party: ActiveParty) -> None:
+        self.active_parties.append(party)
+        self.mm_event_bus.add_party_request_accepted(party.accepter, [party.requester])
+        await self.remove_outstanding_party_request(party)
 
     def update_party_activity(self, party: ActiveParty) -> None:
         """Updates the party activity such that it pushes back the party disband expiration.
@@ -128,6 +143,7 @@ class PartyManager(commands.Cog):
         for active_party in self.active_parties:
             if requester in active_party:
                 self.active_parties.remove(active_party)
+                self.mm_event_bus.add_leave_party(requester, active_party.players())
                 return active_party
 
         return None
@@ -145,9 +161,7 @@ class PartyManager(commands.Cog):
 
             if status == PartyRequestStatus.ACCEPTED:
                 logging.info(f"Party request for {active_party} has been accepted.")
-
-                self.active_parties.append(active_party)
-                self.outstanding_party_request_messages.pop(active_party)
+                await self.add_accepted_party_request(active_party)
 
             if status == PartyRequestStatus.REJECTED:
                 logging.info(f"Party request for {active_party} has been rejected.")
@@ -170,13 +184,9 @@ class PartyManager(commands.Cog):
                 > party_request.message.created_at
             ):
                 logging.info(f"Party request for {active_party} is stale. Removing...")
-
-                await safe_delete_message(party_request.message)
-
-                self.outstanding_party_request_messages.pop(active_party)
+                await self.remove_outstanding_party_request(active_party)
 
                 party_channel = await get_party_channel(self.bot, self.s3_manager)
-
                 if party_channel:
                     embed = discord.Embed(
                         color=COLOR_EMBED, timestamp=datetime.utcnow()

--- a/lib/mm-bot/src/cogs/party_manager.py
+++ b/lib/mm-bot/src/cogs/party_manager.py
@@ -15,7 +15,7 @@ from matchmaking.party.constants import (
 )
 from matchmaking.party.party_request import PartyRequest
 from matchmaking.party.request_status import PartyRequestStatus
-from matchmaking.mm_event_bus import MatchmakingManagerEventBus
+from matchmaking.mm_event_bus import EventType, MatchmakingManagerEventBus
 from models.player_profile import PlayerProfile
 from views.party_request import PartyRequestView
 
@@ -34,6 +34,12 @@ class PartyManager(commands.Cog):
 
         # Represented as an "active" party for which this message will party the two players.
         self.outstanding_party_request_messages: Dict[ActiveParty, PartyRequest] = {}
+        self.new_party_request_queue = self.mm_event_bus.subscribe(
+            EventType.NEW_PARTY_REQUEST
+        )
+        self.cancel_party_request_queue = self.mm_event_bus.subscribe(
+            EventType.CANCEL_PARTY_REQUEST
+        )
 
         registry.register_cog(COG_PARTY_MANAGER, self)
 
@@ -42,12 +48,14 @@ class PartyManager(commands.Cog):
         self.check_party_requests_status.start()
         self.check_for_stale_party_requests.start()
         self.check_inactive_parties_to_disband.start()
+        self.check_event_bus.start()
 
     def cog_unload(self):
         logging.info("Party manager unloading...")
         self.check_party_requests_status.cancel()
         self.check_for_stale_party_requests.cancel()
         self.check_inactive_parties_to_disband.cancel()
+        self.check_event_bus.cancel()
 
     def get_outstanding_party_requests(
         self, requester: PlayerProfile
@@ -61,45 +69,11 @@ class PartyManager(commands.Cog):
     async def add_outstanding_party_request(
         self, requester: PlayerProfile, accepter: PlayerProfile
     ) -> None:
-        active_party = ActiveParty(requester, accepter)
-
-        view = PartyRequestView(active_party)
-
-        if not self.bot:
-            logging.error(
-                "Bot is not initialized in party manager. Skipping sending party request."
-            )
-            return
-
-        party_channel = await get_party_channel(self.bot, self.s3_manager)
-        if not party_channel:
-            logging.error("Party channel not found. Skipping sending party request.")
-            return
-
-        embed = discord.Embed(color=COLOR_EMBED, timestamp=datetime.utcnow())
-        embed.add_field(
-            name="❗ Party System",
-            value=f"<@{accepter.discord_account_id}>, <@{requester.discord_account_id}> has invited you to a party!",
-        )
-        message = await party_channel.send(
-            content=f"<@{accepter.discord_account_id}>",
-            embed=embed,
-            view=view,
-        )
-
         self.mm_event_bus.add_new_party_request(requester, [accepter])
-
-        logging.info(f"Party request sent for {active_party}.")
-
-        self.outstanding_party_request_messages[active_party] = PartyRequest(
-            message, view
-        )
+        logging.info(f"Party request sent from {requester} to {accepter}.")
 
     async def remove_outstanding_party_request(self, party: ActiveParty) -> None:
-        party_request = self.outstanding_party_request_messages[party]
-        await safe_delete_message(party_request.message)
-        self.outstanding_party_request_messages.pop(party)
-        return
+        self.mm_event_bus.add_cancel_party_request(party.requester, [party.accepter])
 
     async def add_accepted_party_request(self, party: ActiveParty) -> None:
         self.active_parties.append(party)
@@ -147,6 +121,61 @@ class PartyManager(commands.Cog):
                 return active_party
 
         return None
+
+    @tasks.loop(seconds=1)
+    async def check_event_bus(self):
+        new_party_request = self.mm_event_bus.get_new_party_request(
+            self.new_party_request_queue
+        )
+        if new_party_request:
+            accepter = new_party_request.receivers[0]
+            requester = new_party_request.initiator
+
+            active_party = ActiveParty(requester, accepter)
+            view = PartyRequestView(active_party)
+
+            if not self.bot:
+                logging.error(
+                    "Bot is not initialized in party manager. Skipping sending party request."
+                )
+                return
+
+            party_channel = await get_party_channel(self.bot, self.s3_manager)
+            if not party_channel:
+                logging.error(
+                    "Party channel not found. Skipping sending party request."
+                )
+                return
+
+            embed = discord.Embed(color=COLOR_EMBED, timestamp=datetime.utcnow())
+            embed.add_field(
+                name="❗ Party System",
+                value=f"<@{accepter.discord_account_id}>, <@{requester.discord_account_id}> has invited you to a party",
+            )
+            message = await party_channel.send(
+                content=f"<@{accepter.discord_account_id}>",
+                embed=embed,
+                view=view,
+            )
+            self.outstanding_party_request_messages[active_party] = PartyRequest(
+                message, view
+            )
+
+        cancel_party_request = self.mm_event_bus.get_cancel_party_request(
+            self.cancel_party_request_queue
+        )
+        if cancel_party_request:
+            active_party_requests = self.get_outstanding_party_requests(
+                cancel_party_request.initiator
+            )
+            for active_party in active_party_requests:
+                if active_party.accepter == cancel_party_request.receivers[0]:
+                    party_request = self.outstanding_party_request_messages[
+                        active_party
+                    ]
+                    await safe_delete_message(party_request.message)
+                    self.outstanding_party_request_messages.pop(active_party)
+                    break
 
     @tasks.loop(seconds=1)
     async def check_party_requests_status(self):

--- a/lib/mm-bot/src/cogs/party_manager.py
+++ b/lib/mm-bot/src/cogs/party_manager.py
@@ -47,6 +47,15 @@ class PartyManager(commands.Cog):
         self.check_for_stale_party_requests.cancel()
         self.check_inactive_parties_to_disband.cancel()
 
+    def get_outstanding_party_requests(
+        self, requester: PlayerProfile
+    ) -> list[ActiveParty]:
+        requests = []
+        for request in self.outstanding_party_request_messages.keys():
+            if request.requester == requester:
+                requests.append(request)
+        return requests
+
     async def add_outstanding_party_request(
         self, requester: PlayerProfile, accepter: PlayerProfile
     ) -> None:

--- a/lib/mm-bot/src/cogs/queue_view_builder.py
+++ b/lib/mm-bot/src/cogs/queue_view_builder.py
@@ -215,6 +215,7 @@ class QueueViewBuilder(commands.Cog):
             value = f"Channel ID: {queue.channel_id}\n"
             value += f"Display Name: {display_name}\n"
             value += f"Campaign Link: {campaign_link}\n"
+            value += f"Primary Leaderboard: {queue.get_primary_leaderboard()}"
             value += f"Active: {active}\n"
 
             embed.add_field(

--- a/lib/mm-bot/src/matchmaking/mm_event_bus.py
+++ b/lib/mm-bot/src/matchmaking/mm_event_bus.py
@@ -21,6 +21,12 @@ class PendingMatchEvent:
     players: List[PlayerProfile]
 
 
+@dataclass
+class PendingPartyRequestEvent:
+    initiator: PlayerProfile
+    receivers: List[PlayerProfile]
+
+
 class EventType(Enum):
     """
     Defines the types of events that can be subscribed to.
@@ -32,6 +38,10 @@ class EventType(Enum):
     QUEUE_UPDATE = 4
     LEFT_QUEUE = 5
     NEW_PENDING_MATCH = 6
+    NEW_PARTY_REQUEST = 7
+    CANCEL_PARTY_REQUEST = 8
+    PARTY_REQUEST_ACCEPTED = 9
+    LEAVE_PARTY = 10
 
 
 class MatchmakingManagerEventBus:
@@ -211,6 +221,66 @@ class MatchmakingManagerEventBus:
         Returns:
             Optional[PendingMatchEvent]: PendingMatchEvent if a new one exists, False otherwise.
         """
+        try:
+            return queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    def add_new_party_request(
+        self, initiator: PlayerProfile, receivers: list[PlayerProfile]
+    ) -> None:
+        new_party_request_subs = self.subscriptions[EventType.NEW_PARTY_REQUEST]
+        for sub in new_party_request_subs:
+            sub.put_nowait(PendingPartyRequestEvent(initiator, receivers))
+
+    def get_new_party_request(
+        self, queue: asyncio.Queue
+    ) -> Optional[PendingPartyRequestEvent]:
+        try:
+            return queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    def add_cancel_party_request(
+        self, initiator: PlayerProfile, receivers: list[PlayerProfile]
+    ) -> None:
+        new_party_request_subs = self.subscriptions[EventType.CANCEL_PARTY_REQUEST]
+        for sub in new_party_request_subs:
+            sub.put_nowait(PendingPartyRequestEvent(initiator, receivers))
+
+    def get_cancel_party_request(
+        self, queue: asyncio.Queue
+    ) -> Optional[PendingPartyRequestEvent]:
+        try:
+            return queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    def add_party_request_accepted(
+        self, initiator: PlayerProfile, receivers: list[PlayerProfile]
+    ) -> None:
+        new_party_request_subs = self.subscriptions[EventType.PARTY_REQUEST_ACCEPTED]
+        for sub in new_party_request_subs:
+            sub.put_nowait(PendingPartyRequestEvent(initiator, receivers))
+
+    def get_party_request_accepted(
+        self, queue: asyncio.Queue
+    ) -> Optional[PendingPartyRequestEvent]:
+        try:
+            return queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    def add_leave_party(
+        self, initiator: PlayerProfile, receivers: list[PlayerProfile]
+    ) -> None:
+        new_party_request_subs = self.subscriptions[EventType.LEAVE_PARTY]
+        for sub in new_party_request_subs:
+            sub.put_nowait(PendingPartyRequestEvent(initiator, receivers))
+
+    def get_leave_party(
+        self, queue: asyncio.Queue
+    ) -> Optional[PendingPartyRequestEvent]:
         try:
             return queue.get_nowait()
         except asyncio.QueueEmpty:

--- a/lib/mm-bot/src/plugin/command_builder.py
+++ b/lib/mm-bot/src/plugin/command_builder.py
@@ -2,6 +2,13 @@ from aws.dynamodb import DynamoDbManager
 from matchmaking.match_queues.active_match_queue import ActiveMatchQueue
 from matchmaking.matches.active_match import ActiveMatch
 from matchmaking.matches.completed_match import CompletedMatch
+from models.player_profile import PlayerProfile
+from plugin.commands.party import (
+    PartyInvitationCommand,
+    ClearPartyCommand,
+    AddPlayersToPartyCommand,
+    RemovePlayersFromPartyCommand,
+)
 from plugin.commands.queue_update import QueueUpdateCommand
 from plugin.commands.match_ready import MatchReadyCommand
 from plugin.commands.match_canceled import MatchCanceledCommand
@@ -29,6 +36,9 @@ class CommandBuilder:
 
     def build_leave_queue(self) -> LeaveQueueResponse:
         return LeaveQueueResponse()
+
+    def build_clear_party(self) -> ClearPartyCommand:
+        return ClearPartyCommand()
 
     def build_match_ready(self, match: ActiveMatch) -> MatchReadyCommand:
         command = MatchReadyCommand(
@@ -98,4 +108,19 @@ class CommandBuilder:
                     player.tm_account_id, player_map[player.tm_account_id], player.elo
                 )
 
+        return command
+
+    def build_party_invitation(self, player: PlayerProfile):
+        return PartyInvitationCommand(invitee_id=player.tm_account_id)
+
+    def build_add_players_to_party(self, players: list[PlayerProfile]):
+        command = AddPlayersToPartyCommand()
+        for player in players:
+            command.add_party_member(player.tm_account_id)
+        return command
+
+    def build_remove_players_from_party(self, players: list[PlayerProfile]):
+        command = RemovePlayersFromPartyCommand()
+        for player in players:
+            command.add_party_member(player.tm_account_id)
         return command

--- a/lib/mm-bot/src/plugin/commands/party.py
+++ b/lib/mm-bot/src/plugin/commands/party.py
@@ -1,0 +1,57 @@
+from plugin.responses.base_response import BaseResponse
+
+
+class PartyInvitationCommand(BaseResponse):
+    def __init__(self, invitee_id: str):
+        super().__init__()
+        self.invitee_id = invitee_id
+
+    def name(self) -> str:
+        return "PartyInvitation"
+
+    def payload(self):
+        return {"TmAccountId": self.invitee_id}
+
+
+class AddPlayersToPartyCommand(BaseResponse):
+    def __init__(self):
+        super().__init__()
+        self.party_members: list[dict] = []
+
+    def name(self) -> str:
+        return "AddPlayersToParty"
+
+    def add_party_member(self, tm_account_id: str):
+        self.party_members.append({"TmAccountId": tm_account_id})
+
+    def payload(self):
+        return {"PartyMembers": self.party_members}
+
+
+class RemovePlayersFromPartyCommand(BaseResponse):
+    def __init__(self):
+        super().__init__()
+        self.party_members: list[dict] = []
+
+    def name(self) -> str:
+        return "RemovePlayersFromParty"
+
+    def add_party_member(self, tm_account_id: str):
+        self.party_members.append({"TmAccountId": tm_account_id})
+
+    def payload(self):
+        return {"PartyMembers": self.party_members}
+
+
+class ClearPartyCommand(BaseResponse):
+    def __init__(self):
+        super().__init__()
+
+    def name(self) -> str:
+        return "ClearParty"
+
+    def payload(self) -> dict:
+        return {}
+
+    def status_code(self):
+        return 200

--- a/lib/mm-bot/src/plugin/connection.py
+++ b/lib/mm-bot/src/plugin/connection.py
@@ -82,7 +82,7 @@ class PluginConnection:
         self, error_message: str = "An error occurred processing request"
     ):
         try:
-            error = ErrorResponse(error_message)
+            error = ErrorResponse(error_message, False)
             await self.send_command(error)
         except Exception:
             pass

--- a/lib/mm-bot/src/plugin/connection.py
+++ b/lib/mm-bot/src/plugin/connection.py
@@ -47,7 +47,8 @@ class PluginConnection:
 
             self._tm_account_id = request.identifier()
 
-            response: BaseResponse = ResponseBuilder().build_response(request)
+            builder = ResponseBuilder()
+            response: BaseResponse = await builder.build_response(request)
             await self.send_command(response)
 
             return False

--- a/lib/mm-bot/src/plugin/constants.py
+++ b/lib/mm-bot/src/plugin/constants.py
@@ -1,3 +1,3 @@
 from packaging.specifiers import SpecifierSet
 
-MIN_VERSION = SpecifierSet(">=0.2.0")
+MIN_VERSION = SpecifierSet(">=0.3.0")

--- a/lib/mm-bot/src/plugin/event_processor.py
+++ b/lib/mm-bot/src/plugin/event_processor.py
@@ -32,4 +32,4 @@ class EventProcessor:
 
     async def loop(self, connections: dict[str, PluginConnection]) -> None:
         for event_queue in self._event_queues:
-            event_queue.check(connections)
+            await event_queue.check(connections)

--- a/lib/mm-bot/src/plugin/event_processor.py
+++ b/lib/mm-bot/src/plugin/event_processor.py
@@ -1,0 +1,35 @@
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+from plugin.event_queues.left_party import LeftPartyEventQueue
+from plugin.event_queues.left_queue import LeftQueueEventQueue
+from plugin.event_queues.match_complete import MatchCompleteEventQueue
+from plugin.event_queues.match_ready import MatchReadyEventQueue
+from plugin.event_queues.party_accepted import PartyAcceptedEventQueue
+from plugin.event_queues.party_invite import PartyInviteEventQueue
+from plugin.event_queues.queue_update import QueueUpdateEventQueue
+
+
+class EventProcessor:
+    _instance = None
+
+    def __new__(cls):
+        if not cls._instance:
+            cls._instance = super(EventProcessor, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, "_initialized"):  # Avoid re-initializing the instance
+            self._initialized = True
+            self._event_queues: list[BaseEventQueue] = [
+                LeftPartyEventQueue(),
+                LeftQueueEventQueue(),
+                MatchCompleteEventQueue(),
+                MatchReadyEventQueue(),
+                QueueUpdateEventQueue(),
+                PartyAcceptedEventQueue(),
+                PartyInviteEventQueue(),
+            ]
+
+    async def loop(self, connections: dict[str, PluginConnection]) -> None:
+        for event_queue in self._event_queues:
+            event_queue.check(connections)

--- a/lib/mm-bot/src/plugin/event_queues/base_event_queue.py
+++ b/lib/mm-bot/src/plugin/event_queues/base_event_queue.py
@@ -1,0 +1,30 @@
+import logging
+from abc import abstractmethod
+from aws.dynamodb import DynamoDbManager
+from cogs.matchmaking_manager_v2 import get_matchmaking_manager_v2
+from matchmaking.mm_event_bus import MatchmakingManagerEventBus
+from plugin.command_builder import CommandBuilder
+from plugin.connection import PluginConnection
+
+
+class BaseEventQueue:
+    def __init__(self):
+        self.command_builder = CommandBuilder()
+        self.ddb_manager = DynamoDbManager()
+        self.mm_manager = get_matchmaking_manager_v2()
+        self.mm_event_bus = MatchmakingManagerEventBus()
+
+    async def send_command(self, client: PluginConnection, response):
+        try:
+            if client:
+                await client.send_command(response)
+                return True
+        except Exception as e:
+            logging.exception(
+                f"Failed trying to sending command to user: {client.identifier()}", e
+            )
+        return False
+
+    @abstractmethod
+    async def check(self, connections: dict[str, PluginConnection]):
+        pass

--- a/lib/mm-bot/src/plugin/event_queues/left_party.py
+++ b/lib/mm-bot/src/plugin/event_queues/left_party.py
@@ -1,0 +1,20 @@
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class LeftPartyEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.LEAVE_PARTY)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_leave_party(self.queue)
+        if event is not None:
+            command = self.command_builder.build_remove_players_from_party(
+                [event.initiator]
+            )
+            for player in event.receivers:
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, command)

--- a/lib/mm-bot/src/plugin/event_queues/left_queue.py
+++ b/lib/mm-bot/src/plugin/event_queues/left_queue.py
@@ -1,0 +1,16 @@
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class LeftQueueEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.LEFT_QUEUE)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_new_left_queue(self.queue)
+        if event is not None:
+            command = self.command_builder.build_leave_queue()
+            for player in event:
+                await self.send_command(player.tm_account_id, command)

--- a/lib/mm-bot/src/plugin/event_queues/left_queue.py
+++ b/lib/mm-bot/src/plugin/event_queues/left_queue.py
@@ -13,4 +13,6 @@ class LeftQueueEventQueue(BaseEventQueue):
         if event is not None:
             command = self.command_builder.build_leave_queue()
             for player in event:
-                await self.send_command(player.tm_account_id, command)
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, command)

--- a/lib/mm-bot/src/plugin/event_queues/match_complete.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_complete.py
@@ -17,4 +17,6 @@ class MatchCompleteEventQueue(BaseEventQueue):
             )
             completed_match_command = self.command_builder.build_match_results(event)
             for player in event.active_match.participants():
-                await self.send_command(player.tm_account_id, completed_match_command)
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, completed_match_command)

--- a/lib/mm-bot/src/plugin/event_queues/match_complete.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_complete.py
@@ -1,0 +1,20 @@
+import logging
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class MatchCompleteEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.NEW_COMPLETED_MATCH)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_new_completed_match(self.queue)
+        if event is not None:
+            logging.info(
+                f"Sending Match Completed request to plugins for match {event.active_match.match_id}"
+            )
+            completed_match_command = self.command_builder.build_match_results(event)
+            for player in event.active_match.participants():
+                await self.send_command(player.tm_account_id, completed_match_command)

--- a/lib/mm-bot/src/plugin/event_queues/match_ready.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_ready.py
@@ -20,3 +20,5 @@ class MatchReadyEventQueue(BaseEventQueue):
                 client = connections.get(player.tm_account_id)
                 if client:
                     await self.send_command(client, command)
+
+            self.mm_event_bus.add_queue_update(event.match_queue.queue_id)

--- a/lib/mm-bot/src/plugin/event_queues/match_ready.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_ready.py
@@ -1,0 +1,20 @@
+import logging
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class MatchReadyEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.NEW_ACTIVE_MATCH)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_new_active_match(self.queue)
+        if event is not None:
+            logging.info(
+                f"Sending Match Ready request to plugins for match {event.match_id}"
+            )
+            command = self.command_builder.build_match_ready(event)
+            for player in event.participants():
+                await self.send_command(player.tm_account_id, command)

--- a/lib/mm-bot/src/plugin/event_queues/match_ready.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_ready.py
@@ -17,4 +17,6 @@ class MatchReadyEventQueue(BaseEventQueue):
             )
             command = self.command_builder.build_match_ready(event)
             for player in event.participants():
-                await self.send_command(player.tm_account_id, command)
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, command)

--- a/lib/mm-bot/src/plugin/event_queues/party_accepted.py
+++ b/lib/mm-bot/src/plugin/event_queues/party_accepted.py
@@ -1,0 +1,18 @@
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class PartyAcceptedEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.PARTY_REQUEST_ACCEPTED)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_party_request_accepted(self.queue)
+        if event is not None:
+            command = self.command_builder.build_add_players_to_party([event.initiator])
+            for player in event.receivers:
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, command)

--- a/lib/mm-bot/src/plugin/event_queues/party_invite.py
+++ b/lib/mm-bot/src/plugin/event_queues/party_invite.py
@@ -1,0 +1,18 @@
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class PartyInviteEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.NEW_PARTY_REQUEST)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_new_party_request(self.queue)
+        if event is not None:
+            command = self.command_builder.build_party_invitation([event.initiator])
+            for player in event.receivers:
+                client = connections.get(player.tm_account_id)
+                if client:
+                    await self.send_command(client, command)

--- a/lib/mm-bot/src/plugin/event_queues/party_invite.py
+++ b/lib/mm-bot/src/plugin/event_queues/party_invite.py
@@ -11,7 +11,7 @@ class PartyInviteEventQueue(BaseEventQueue):
     async def check(self, connections: dict[str, PluginConnection]) -> None:
         event = self.mm_event_bus.get_new_party_request(self.queue)
         if event is not None:
-            command = self.command_builder.build_party_invitation([event.initiator])
+            command = self.command_builder.build_party_invitation(event.initiator)
             for player in event.receivers:
                 client = connections.get(player.tm_account_id)
                 if client:

--- a/lib/mm-bot/src/plugin/event_queues/queue_update.py
+++ b/lib/mm-bot/src/plugin/event_queues/queue_update.py
@@ -1,0 +1,18 @@
+from matchmaking.mm_event_bus import EventType
+from plugin.connection import PluginConnection
+from plugin.event_queues.base_event_queue import BaseEventQueue
+
+
+class QueueUpdateEventQueue(BaseEventQueue):
+    def __init__(self):
+        super().__init__()
+        self.queue = self.mm_event_bus.subscribe(EventType.QUEUE_UPDATE)
+
+    async def check(self, connections: dict[str, PluginConnection]) -> None:
+        event = self.mm_event_bus.get_new_queue_update(self.queue)
+        if event is not None:
+            queue = self.mm_manager.get_queue(event)
+            if queue:
+                queue_update_command = self.command_builder.build_queue_update(queue)
+                for tm_account_id, _ in connections.items():
+                    await self.send_command(tm_account_id, queue_update_command)

--- a/lib/mm-bot/src/plugin/event_queues/queue_update.py
+++ b/lib/mm-bot/src/plugin/event_queues/queue_update.py
@@ -14,5 +14,5 @@ class QueueUpdateEventQueue(BaseEventQueue):
             queue = self.mm_manager.get_queue(event)
             if queue:
                 queue_update_command = self.command_builder.build_queue_update(queue)
-                for tm_account_id, _ in connections.items():
-                    await self.send_command(tm_account_id, queue_update_command)
+                for _, client in connections.items():
+                    await self.send_command(client, queue_update_command)

--- a/lib/mm-bot/src/plugin/request_parser.py
+++ b/lib/mm-bot/src/plugin/request_parser.py
@@ -4,12 +4,19 @@ import logging
 from packaging.version import parse, InvalidVersion
 from plugin.constants import MIN_VERSION
 from plugin.requests.base_request import BaseRequest
+from plugin.requests.initialize import InitializeRequest
 from plugin.requests.get_queues import GetQueuesRequest
 from plugin.requests.invalid_version import InvalidVersionRequest
 from plugin.requests.join_queue import JoinQueueRequest
 from plugin.requests.leave_queue import LeaveQueueRequest
 from plugin.requests.get_leaderboards import GetLeaderboardsRequest
 from plugin.requests.get_stats import GetStatsRequest
+from plugin.requests.party import (
+    PartyInviteRequest,
+    CancelPartyInviteRequest,
+    AcceptPartyInviteRequest,
+    LeavePartyRequest,
+)
 from plugin.requests.ping import PingRequest
 
 
@@ -39,6 +46,8 @@ class RequestParser:
         payload: dict = obj.get("Payload", {})
 
         match command:
+            case "Initialize":
+                return InitializeRequest(user)
             case "GetQueues":
                 return GetQueuesRequest(user)
             case "JoinQueue":
@@ -49,6 +58,14 @@ class RequestParser:
                 return GetLeaderboardsRequest(user)
             case "GetStats":
                 return GetStatsRequest(user)
+            case "PartyInvite":
+                return PartyInviteRequest(user, payload.get("TmAccountId"))
+            case "CancelPartyInvite":
+                return CancelPartyInviteRequest(user, payload.get("TmAccountId"))
+            case "AcceptPartyInvite":
+                return AcceptPartyInviteRequest(user, payload.get("TmAccountId"))
+            case "LeaveParty":
+                return LeavePartyRequest(user)
             case "Ping":
                 return PingRequest(user)
             case _:

--- a/lib/mm-bot/src/plugin/request_parser.py
+++ b/lib/mm-bot/src/plugin/request_parser.py
@@ -74,12 +74,10 @@ class RequestParser:
                 return RegisterAccountRequest(
                     user,
                     payload.get("DiscordUsername") or "",
-                    payload.get("UbisoftAccountId") or "",
+                    payload.get("TmAccountId") or "",
                 )
             case "CheckRegistration":
-                return CheckRegistrationRequest(
-                    user, payload.get("UbisoftAccountId") or ""
-                )
+                return CheckRegistrationRequest(user, payload.get("TmAccountId") or "")
             case _:
                 return None
 

--- a/lib/mm-bot/src/plugin/requests/initialize.py
+++ b/lib/mm-bot/src/plugin/requests/initialize.py
@@ -1,0 +1,9 @@
+from plugin.requests.base_request import BaseRequest
+
+
+class InitializeRequest(BaseRequest):
+    def __init__(self, user):
+        super().__init__(user)
+
+    def name(cls) -> str:
+        return "Initialize"

--- a/lib/mm-bot/src/plugin/requests/party.py
+++ b/lib/mm-bot/src/plugin/requests/party.py
@@ -1,0 +1,42 @@
+from plugin.requests.base_request import BaseRequest
+
+
+class PartyInviteRequest(BaseRequest):
+    invitee_id: str | None = None
+
+    def __init__(self, user, invitee_id):
+        super().__init__(user)
+        self.invitee_id = invitee_id
+
+    def name(cls) -> str:
+        return "PartyInvite"
+
+
+class CancelPartyInviteRequest(BaseRequest):
+    invitee_id: str | None = None
+
+    def __init__(self, user, invitee_id):
+        super().__init__(user)
+        self.invitee_id = invitee_id
+
+    def name(cls) -> str:
+        return "CancelPartyInvite"
+
+
+class AcceptPartyInviteRequest(BaseRequest):
+    inviter_id: str | None = None
+
+    def __init__(self, user, inviter_id):
+        super().__init__(user)
+        self.inviter_id = inviter_id
+
+    def name(cls) -> str:
+        return "AcceptPartyInvite"
+
+
+class LeavePartyRequest(BaseRequest):
+    def __init__(self, user):
+        super().__init__(user)
+
+    def name(cls) -> str:
+        return "LeaveParty"

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -50,7 +50,7 @@ class ResponseBuilder:
             self._ddb_manager = DynamoDbManager()
             self._command_builder = CommandBuilder()
 
-    def build_response(self, request: BaseRequest) -> BaseResponse:
+    async def build_response(self, request: BaseRequest) -> BaseResponse:
         profile: PlayerProfile = (
             self._ddb_manager.query_player_profile_for_tm_account_id(
                 request.identifier()
@@ -76,6 +76,10 @@ class ResponseBuilder:
                 return self._get_party_invite_response(profile, request)
             case CancelPartyInviteRequest():
                 return self._get_cancel_party_invite_response(profile, request)
+            case AcceptPartyInviteRequest():
+                return await self._get_accept_party_invite_response(profile, request)
+            case LeavePartyRequest():
+                return self._get_leave_party_response(profile, request)
             case PingRequest():
                 return self._ping_response(profile, request)
             case InvalidVersionRequest():
@@ -301,7 +305,7 @@ class ResponseBuilder:
             if player_party and invitee in player_party.players():
                 return ErrorResponse("You are already in a party with this player!")
 
-        # TODO: send party request through discord and plugins
+            party_manager.add_outstanding_party_request(profile, invitee)
 
         return PartyInviteResponse(invitee.tm_account_id)
 
@@ -319,12 +323,12 @@ class ResponseBuilder:
             active_requests = party_manager.get_outstanding_party_requests(profile)
             for party_request in active_requests:
                 if party_request.accepter == invitee:
-                    # TODO: clean up party request
+                    party_manager.remove_outstanding_party_request(party_request)
                     break
 
         return CancelPartyInviteResponse(invitee.tm_account_id)
 
-    def _get_accept_party_invite_response(
+    async def _get_accept_party_invite_response(
         self, profile: PlayerProfile, request: AcceptPartyInviteRequest
     ) -> BaseResponse:
         inviter: PlayerProfile = (
@@ -338,8 +342,7 @@ class ResponseBuilder:
             for party_request in active_requests:
                 if party_request.accepter == profile:
                     found_invite = True
-                    # TODO: accept party invite
-                    # TODO: clean up party request
+                    await party_manager.add_accepted_party_request(party_request)
                     break
 
         if not found_invite:
@@ -363,7 +366,6 @@ class ResponseBuilder:
         party_manager = get_party_manager()
         if party_manager:
             party_manager.remove_party(profile)
-            # TODO: clean up party members
 
         return self._command_builder.build_clear_party()
 

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -403,19 +403,20 @@ class ResponseBuilder:
 
         # Validate inputs
         if not request.discord_username or not request.ubisoft_account_id:
-            return ErrorResponse("Missing required fields")
+            return ErrorResponse("Missing required fields", False)
 
         # Validate Ubisoft account ID format (UUID)
         UUID_REGEX = re.compile(
             r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", re.I
         )
         if not UUID_REGEX.match(request.ubisoft_account_id):
-            return ErrorResponse("Invalid Ubisoft account ID format")
+            return ErrorResponse("Invalid Ubisoft account ID format", False)
 
         # Validate Discord username format
         if not self._is_valid_discord_username(request.discord_username):
             return ErrorResponse(
-                "Invalid Discord username format. Use either 'username#1234' or '@username' format"
+                "Invalid Discord username format. Use either 'username#1234' or '@username' format",
+                False,
             )
 
         # Resolve Discord username to actual Discord user ID
@@ -425,17 +426,17 @@ class ResponseBuilder:
             )
             if discord_user_id is None:
                 return ErrorResponse(
-                    f"Discord user '{request.discord_username}' not found"
+                    f"Discord user '{request.discord_username}' not found", False
                 )
         except Exception as e:
-            return ErrorResponse(f"Failed to resolve Discord username: {str(e)}")
+            return ErrorResponse(f"Failed to resolve Discord username: {str(e)}", False)
 
         # Check for existing registrations by Ubisoft account
         existing_tm_account = self._ddb_manager.query_player_profile_for_tm_account_id(
             request.ubisoft_account_id
         )
         if existing_tm_account:
-            return ErrorResponse("Ubisoft account already registered")
+            return ErrorResponse("Ubisoft account already registered", False)
 
         # Check if this Discord user ID is already registered
         existing_discord_account = (
@@ -445,7 +446,8 @@ class ResponseBuilder:
         )
         if existing_discord_account:
             return ErrorResponse(
-                f"Discord user '{request.discord_username}' is already registered"
+                f"Discord user '{request.discord_username}' is already registered",
+                False,
             )
 
         # Create the registration with actual Discord user ID
@@ -456,7 +458,7 @@ class ResponseBuilder:
         if success:
             return RegisterAccountResponse()
         else:
-            return ErrorResponse("Failed to create registration")
+            return ErrorResponse("Failed to create registration", False)
 
     def _resolve_discord_username_to_id_sync(self, username: str) -> int | None:
         """Resolve Discord username to user ID using Discord REST API (synchronous)"""

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -75,7 +75,7 @@ class ResponseBuilder:
             case PartyInviteRequest():
                 return await self._get_party_invite_response(profile, request)
             case CancelPartyInviteRequest():
-                return self._get_cancel_party_invite_response(profile, request)
+                return await self._get_cancel_party_invite_response(profile, request)
             case AcceptPartyInviteRequest():
                 return await self._get_accept_party_invite_response(profile, request)
             case LeavePartyRequest():
@@ -311,7 +311,7 @@ class ResponseBuilder:
 
         return PartyInviteResponse(invitee.tm_account_id)
 
-    def _get_cancel_party_invite_response(
+    async def _get_cancel_party_invite_response(
         self, profile: PlayerProfile, request: CancelPartyInviteRequest
     ) -> BaseResponse:
         invitee: PlayerProfile = (
@@ -325,7 +325,7 @@ class ResponseBuilder:
             active_requests = party_manager.get_outstanding_party_requests(profile)
             for party_request in active_requests:
                 if party_request.accepter == invitee:
-                    party_manager.remove_outstanding_party_request(party_request)
+                    await party_manager.remove_outstanding_party_request(party_request)
                     break
 
         return CancelPartyInviteResponse(invitee.tm_account_id)

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -73,7 +73,7 @@ class ResponseBuilder:
             case GetStatsRequest():
                 return self._get_stats_response(profile, request)
             case PartyInviteRequest():
-                return self._get_party_invite_response(profile, request)
+                return await self._get_party_invite_response(profile, request)
             case CancelPartyInviteRequest():
                 return self._get_cancel_party_invite_response(profile, request)
             case AcceptPartyInviteRequest():
@@ -133,6 +133,8 @@ class ResponseBuilder:
         if active_match:
             match_ready_command = self._command_builder.build_match_ready(active_match)
             response.add_match(match_ready_command.payload())
+
+        return response
 
     def _get_queues_response(
         self, profile: PlayerProfile, request: GetQueuesResponse
@@ -288,7 +290,7 @@ class ResponseBuilder:
     def _get_stats_response(self, profile: PlayerProfile, request: GetStatsRequest):
         return GetStatsResponse()
 
-    def _get_party_invite_response(
+    async def _get_party_invite_response(
         self, profile: PlayerProfile, request: PartyInviteRequest
     ) -> BaseResponse:
         invitee: PlayerProfile = (
@@ -305,7 +307,7 @@ class ResponseBuilder:
             if player_party and invitee in player_party.players():
                 return ErrorResponse("You are already in a party with this player!")
 
-            party_manager.add_outstanding_party_request(profile, invitee)
+            await party_manager.add_outstanding_party_request(profile, invitee)
 
         return PartyInviteResponse(invitee.tm_account_id)
 

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -5,20 +5,33 @@ from matchmaking.match_queues.active_match_queue import ActiveMatchQueue
 from models.player_profile import PlayerProfile
 from plugin.command_builder import CommandBuilder
 from plugin.requests.base_request import BaseRequest
+from plugin.requests.initialize import InitializeRequest
 from plugin.requests.get_queues import GetQueuesRequest
 from plugin.requests.invalid_version import InvalidVersionRequest
 from plugin.requests.join_queue import JoinQueueRequest
 from plugin.requests.leave_queue import LeaveQueueRequest
 from plugin.requests.get_leaderboards import GetLeaderboardsRequest
 from plugin.requests.get_stats import GetStatsRequest
+from plugin.requests.party import (
+    PartyInviteRequest,
+    LeavePartyRequest,
+    AcceptPartyInviteRequest,
+    CancelPartyInviteRequest,
+)
 from plugin.requests.ping import PingRequest
 from plugin.responses.base_response import BaseResponse
 from plugin.responses.error import ErrorResponse
+from plugin.responses.initialize import InitializeResponse
 from plugin.responses.get_queues import GetQueuesResponse
 from plugin.responses.join_queue import JoinQueueResponse
 from plugin.responses.leave_queue import LeaveQueueResponse
 from plugin.responses.get_leaderboards import GetLeaderboardsResponse
 from plugin.responses.get_stats import GetStatsResponse
+from plugin.responses.party import (
+    PartyInviteResponse,
+    AcceptPartyInviteResponse,
+    CancelPartyInviteResponse,
+)
 from plugin.responses.ping_response import PingResponse
 
 
@@ -44,9 +57,11 @@ class ResponseBuilder:
             )
         )
         if not profile:
-            return ErrorResponse("You have not registered your account yet")
+            return ErrorResponse("You have not registered your account yet", False)
 
         match request:
+            case InitializeRequest():
+                return self._get_initialize_response(profile, request)
             case GetQueuesRequest():
                 return self._get_queues_response(profile, request)
             case JoinQueueRequest():
@@ -57,22 +72,67 @@ class ResponseBuilder:
                 return self._get_leaderboards_response(profile, request)
             case GetStatsRequest():
                 return self._get_stats_response(profile, request)
+            case PartyInviteRequest():
+                return self._get_party_invite_response(profile, request)
+            case CancelPartyInviteRequest():
+                return self._get_cancel_party_invite_response(profile, request)
             case PingRequest():
                 return self._ping_response(profile, request)
             case InvalidVersionRequest():
                 return ErrorResponse(
-                    "Your plugin is out of date. Please update to the latest version!"
+                    "Your plugin is out of date. Please update to the latest version!",
+                    False,
                 )
             case _:
-                return ErrorResponse("Invalid request received")
+                return ErrorResponse("Invalid request received", False)
 
-    def _get_queues_response(
-        self, profile: PlayerProfile, request: GetQueuesRequest
-    ) -> BaseResponse:
+    def _get_initialize_response(
+        self, profile: PlayerProfile, request: InitializeRequest
+    ) -> InitializeResponse:
+        response = InitializeResponse()
+
+        queues = self._get_queues_response(profile, request)
+        response.add_queues(queues.payload().get("Queues"))
+
+        current_queue = None
+        for active_queue in self._mm_manager.active_queues:
+            if active_queue.is_player_queued(profile):
+                current_queue = active_queue
+                break
+
+        if current_queue is not None:
+            response.add_current_queue(current_queue.queue.queue_id)
+
+        party_manager = get_party_manager()
+        if party_manager:
+            player_party = party_manager.get_player_party(profile)
+            if player_party is not None:
+                party_manager.update_party_activity(player_party)
+
+                if current_queue is not None:
+                    for player in player_party:
+                        player_elo = 0
+                        try:
+                            player_elo = self._ddb_manager.get_or_create_player_elo(
+                                player.tm_account_id,
+                                current_queue.queue.get_primary_leaderboard(),
+                            ).elo
+                        except Exception:
+                            pass
+
+                        response.add_party_member(player.tm_account_id, player_elo)
+                else:
+                    for player in player_party:
+                        response.add_party_member(player.tm_account_id, -1)
+
         active_match = self._mm_manager.find_match_with_player(profile)
         if active_match:
-            return self._command_builder.build_match_ready(active_match)
+            match_ready_command = self._command_builder.build_match_ready(active_match)
+            response.add_match(match_ready_command.payload())
 
+    def _get_queues_response(
+        self, profile: PlayerProfile, request: GetQueuesResponse
+    ) -> BaseResponse:
         response = GetQueuesResponse()
 
         sorted_queues: list[ActiveMatchQueue] = sorted(
@@ -87,12 +147,6 @@ class ResponseBuilder:
             except Exception:
                 pass
 
-            if active_queue.is_player_queued(profile):
-                return self._join_queue_response(
-                    profile,
-                    JoinQueueRequest(request.identifier(), active_queue.queue.queue_id),
-                )
-
             response.add_queue(
                 active_queue.queue.queue_id,
                 active_queue.queue.display_name,
@@ -103,10 +157,6 @@ class ResponseBuilder:
         return response
 
     def _join_queue_response(self, profile: PlayerProfile, request: JoinQueueRequest):
-        active_match = self._mm_manager.find_match_with_player(profile)
-        if active_match:
-            return self._command_builder.build_match_ready(active_match)
-
         queue = self._mm_manager.get_queue(request.queue_id)
         if not queue:
             return ErrorResponse(
@@ -153,10 +203,15 @@ class ResponseBuilder:
                 add_count = len(player_party.players())
 
             for player in player_party:
-                player_elo = self._ddb_manager.get_or_create_player_elo(
-                    player.tm_account_id, queue.queue.get_primary_leaderboard()
-                )
-                response.add_party_member(player.tm_account_id, player_elo.elo)
+                player_elo = 0
+                try:
+                    player_elo = self._ddb_manager.get_or_create_player_elo(
+                        player.tm_account_id, queue.queue.get_primary_leaderboard()
+                    ).elo
+                except Exception:
+                    pass
+
+                response.add_party_member(player.tm_account_id, player_elo)
         else:
             if not queue.is_player_queued(profile):
                 result = self._mm_manager.add_party_to_queue(
@@ -171,7 +226,7 @@ class ResponseBuilder:
 
     def _leave_queue_response(self, profile: PlayerProfile, request: LeaveQueueRequest):
         if self._mm_manager.is_player_in_match(profile):
-            return ErrorResponse("Cannot leave queue while in a match", True)
+            return ErrorResponse("Cannot leave queue while in a match")
 
         party_manager = get_party_manager()
         if party_manager:
@@ -228,6 +283,89 @@ class ResponseBuilder:
 
     def _get_stats_response(self, profile: PlayerProfile, request: GetStatsRequest):
         return GetStatsResponse()
+
+    def _get_party_invite_response(
+        self, profile: PlayerProfile, request: PartyInviteRequest
+    ) -> BaseResponse:
+        invitee: PlayerProfile = (
+            self._ddb_manager.query_player_profile_for_tm_account_id(request.invitee_id)
+        )
+        if not invitee:
+            return ErrorResponse(
+                "The player you invited has not registered with Better Matchmaking"
+            )
+
+        party_manager = get_party_manager()
+        if party_manager:
+            player_party = party_manager.get_player_party(profile)
+            if player_party and invitee in player_party.players():
+                return ErrorResponse("You are already in a party with this player!")
+
+        # TODO: send party request through discord and plugins
+
+        return PartyInviteResponse(invitee.tm_account_id)
+
+    def _get_cancel_party_invite_response(
+        self, profile: PlayerProfile, request: CancelPartyInviteRequest
+    ) -> BaseResponse:
+        invitee: PlayerProfile = (
+            self._ddb_manager.query_player_profile_for_tm_account_id(request.invitee_id)
+        )
+        if not invitee:
+            return CancelPartyInviteResponse(request.invitee_id)
+
+        party_manager = get_party_manager()
+        if party_manager:
+            active_requests = party_manager.get_outstanding_party_requests(profile)
+            for party_request in active_requests:
+                if party_request.accepter == invitee:
+                    # TODO: clean up party request
+                    break
+
+        return CancelPartyInviteResponse(invitee.tm_account_id)
+
+    def _get_accept_party_invite_response(
+        self, profile: PlayerProfile, request: AcceptPartyInviteRequest
+    ) -> BaseResponse:
+        inviter: PlayerProfile = (
+            self._ddb_manager.query_player_profile_for_tm_account_id(request.inviter_id)
+        )
+
+        found_invite = False
+        party_manager = get_party_manager()
+        if party_manager:
+            active_requests = party_manager.get_outstanding_party_requests(inviter)
+            for party_request in active_requests:
+                if party_request.accepter == profile:
+                    found_invite = True
+                    # TODO: accept party invite
+                    # TODO: clean up party request
+                    break
+
+        if not found_invite:
+            return ErrorResponse(
+                "The invite you are trying to accept is no longer valid"
+            )
+
+        party = party_manager.get_player_party(profile)
+        if party:
+            response = AcceptPartyInviteResponse()
+            for player in party.players():
+                response.add_party_member(player.tm_account_id)
+
+            return response
+
+        return ErrorResponse("The party you are trying to join does not exist")
+
+    def _get_leave_party_response(
+        self, profile: PlayerProfile, request: LeavePartyRequest
+    ) -> BaseRequest:
+        party_manager = get_party_manager()
+        if party_manager:
+            party_manager.remove_party(profile)
+            # TODO: clean up party members
+
+        return self._command_builder.build_clear_party()
 
     def _ping_response(self, profile: PlayerProfile, request: PingRequest):
         for active_queue in self._mm_manager.active_queues:

--- a/lib/mm-bot/src/plugin/responses/error.py
+++ b/lib/mm-bot/src/plugin/responses/error.py
@@ -2,7 +2,7 @@ from plugin.responses.base_response import BaseResponse
 
 
 class ErrorResponse(BaseResponse):
-    def __init__(self, error_message, keep_alive=False):
+    def __init__(self, error_message, keep_alive=True):
         super().__init__()
         self._error_message = error_message
         self._keep_alive = keep_alive

--- a/lib/mm-bot/src/plugin/responses/initialize.py
+++ b/lib/mm-bot/src/plugin/responses/initialize.py
@@ -1,0 +1,42 @@
+from plugin.responses.base_response import BaseResponse
+
+
+class InitializeResponse(BaseResponse):
+    def __init__(self):
+        super().__init__()
+        self.queues: list[dict] = []
+        self.party_members: list[dict] = []
+        self.current_queue_id: str | None = None
+        self.match: dict | None = None
+
+    def name(self) -> str:
+        return "InitializeResponse"
+
+    def add_queues(self, queues):
+        self.queues = queues
+
+    def add_party_member(self, tm_account_id: str, points: int):
+        self.party_members.append({"TmAccountId": tm_account_id, "Points": points})
+
+    def add_current_queue(self, queue_id: str):
+        self.current_queue_id = queue_id
+
+    def add_match(self, match: dict):
+        self.match = match
+
+    def payload(self) -> dict:
+        data: dict = {
+            "Queues": self.queues,
+            "PartyMembers": self.party_members,
+        }
+
+        if self.current_queue_id is not None:
+            data["Queue"] = {"Id": self.current_queue_id}
+
+        if self.match is not None:
+            data["Match"] = self.match
+
+        return data
+
+    def status_code(self):
+        return 200

--- a/lib/mm-bot/src/plugin/responses/party.py
+++ b/lib/mm-bot/src/plugin/responses/party.py
@@ -1,0 +1,50 @@
+from plugin.responses.base_response import BaseResponse
+
+
+class PartyInviteResponse(BaseResponse):
+    def __init__(self, tm_account_id: str):
+        super().__init__()
+        self.invitee_id = tm_account_id
+
+    def name(self) -> str:
+        return "PartyInviteResponse"
+
+    def payload(self) -> dict:
+        return {
+            "TmAccountId": self.invitee_id,
+        }
+
+    def status_code(self):
+        return 200
+
+
+class CancelPartyInviteResponse(BaseResponse):
+    def __init__(self, tm_account_id: str):
+        super().__init__()
+        self.invitee_id = tm_account_id
+
+    def name(self) -> str:
+        return "CancelPartyInviteResponse"
+
+    def payload(self) -> dict:
+        return {
+            "TmAccountId": self.invitee_id,
+        }
+
+    def status_code(self):
+        return 200
+
+
+class AcceptPartyInviteResponse(BaseResponse):
+    def __init__(self):
+        super().__init__()
+        self.party_members: list[dict] = []
+
+    def name(self) -> str:
+        return "AcceptPartyInviteResponse"
+
+    def add_party_member(self, tm_account_id: str):
+        self.party_members.append({"TmAccountId": tm_account_id})
+
+    def payload(self):
+        return {"PartyMembers": self.party_members}

--- a/lib/mm-bot/src/plugin/server.py
+++ b/lib/mm-bot/src/plugin/server.py
@@ -3,10 +3,8 @@ import logging
 import threading
 from aws.dynamodb import DynamoDbManager
 from cogs.matchmaking_manager_v2 import get_matchmaking_manager_v2
-from matchmaking.mm_event_bus import EventType, MatchmakingManagerEventBus
 from plugin.connection import PluginConnection
-from plugin.responses.base_response import BaseResponse
-from plugin.command_builder import CommandBuilder
+from plugin.event_processor import EventProcessor
 
 
 class PluginServer:
@@ -24,21 +22,9 @@ class PluginServer:
             self._loop = None
             self._server = None
             self._connected_clients: dict[str, PluginConnection] = {}
-            self._command_builder = CommandBuilder()
             self._ddb_manager = DynamoDbManager()
             self._mm_manager = get_matchmaking_manager_v2()
-            self._mm_event_bus = MatchmakingManagerEventBus()
-            self._match_ready_queue = self._mm_event_bus.subscribe(
-                EventType.NEW_ACTIVE_MATCH
-            )
-            self._match_complete_queue = self._mm_event_bus.subscribe(
-                EventType.NEW_COMPLETED_MATCH
-            )
-            self._queue_update_queue = self._mm_event_bus.subscribe(
-                EventType.QUEUE_UPDATE
-            )
-            self._left_queue_queue = self._mm_event_bus.subscribe(EventType.LEFT_QUEUE)
-
+            self._event_processor = EventProcessor()
             logging.info("Instantiating plugin server.")
 
     def startup(self):
@@ -72,18 +58,6 @@ class PluginServer:
         except Exception:
             logging.error(f"Unable to remove player {tm_account_id} from queues")
 
-    async def try_send_command(self, tm_account_id: str, response: BaseResponse):
-        try:
-            client: PluginConnection = self._connected_clients.get(tm_account_id)
-            if client:
-                await client.send_command(response)
-                return True
-        except Exception as e:
-            logging.exception(
-                f"Failed trying to sending command to user: {tm_account_id}", e
-            )
-        return False
-
     def _start_event_loops(self):
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
@@ -96,59 +70,7 @@ class PluginServer:
         logging.info("Starting plugin server event bus loop")
         while not self._stopped:
             try:
-                completed_match = self._mm_event_bus.get_new_completed_match(
-                    self._match_complete_queue
-                )
-                if completed_match is not None:
-                    logging.info(
-                        f"Sending Match Completed request to plugins for match {completed_match.active_match.match_id}"
-                    )
-                    completed_match_command = self._command_builder.build_match_results(
-                        completed_match
-                    )
-                    for player in completed_match.active_match.participants():
-                        await self.try_send_command(
-                            player.tm_account_id, completed_match_command
-                        )
-
-                new_match = self._mm_event_bus.get_new_active_match(
-                    self._match_ready_queue
-                )
-                if new_match is not None:
-                    logging.info(
-                        f"Sending Match Ready request to plugins for match {new_match.match_id}"
-                    )
-                    new_match_command = self._command_builder.build_match_ready(
-                        new_match
-                    )
-                    for player in new_match.participants():
-                        await self.try_send_command(
-                            player.tm_account_id, new_match_command
-                        )
-
-                left_queue = self._mm_event_bus.get_new_left_queue(
-                    self._left_queue_queue
-                )
-                if left_queue is not None:
-                    left_queue_command = self._command_builder.build_leave_queue()
-                    for player in left_queue:
-                        await self.try_send_command(
-                            player.tm_account_id, left_queue_command
-                        )
-
-                queue_update = self._mm_event_bus.get_new_queue_update(
-                    self._queue_update_queue
-                )
-                if queue_update is not None:
-                    queue = self._mm_manager.get_queue(queue_update)
-                    if queue:
-                        queue_update_command = self._command_builder.build_queue_update(
-                            queue
-                        )
-                        for tm_account_id, _ in self._connected_clients.items():
-                            await self.try_send_command(
-                                tm_account_id, queue_update_command
-                            )
+                await self._event_processor.loop(self._connected_clients)
             except Exception as e:
                 logging.exception("Exception occurred in plugin event worker", e)
             finally:

--- a/lib/mm-bot/src/views/party_request.py
+++ b/lib/mm-bot/src/views/party_request.py
@@ -1,6 +1,7 @@
 import discord
 from matchmaking.party.active_party import ActiveParty
 from matchmaking.party.request_status import PartyRequestStatus
+from matchmaking.mm_event_bus import MatchmakingManagerEventBus
 
 
 class PartyRequestView(discord.ui.View):
@@ -8,6 +9,7 @@ class PartyRequestView(discord.ui.View):
         super().__init__()
         self.active_party = active_party
         self.status: PartyRequestStatus = PartyRequestStatus.PENDING
+        self.mm_event_bus = MatchmakingManagerEventBus()
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         """Ensure that only the accepter can interact with the buttons."""

--- a/lib/mm-bot/test/plugin/test_registration.py
+++ b/lib/mm-bot/test/plugin/test_registration.py
@@ -208,7 +208,7 @@ class TestRegistrationResponses(unittest.TestCase):
 
     def test_register_account_error_response(self):
         """Test creating an error response for registration failure"""
-        response = ErrorResponse("Registration failed")
+        response = ErrorResponse("Registration failed", False)
 
         self.assertEqual(response.name(), "ErrorResponse")
         self.assertEqual(response.status_code(), 500)

--- a/lib/mm-bot/test/plugin/test_registration.py
+++ b/lib/mm-bot/test/plugin/test_registration.py
@@ -46,7 +46,7 @@ class TestRegistrationRequests(unittest.TestCase):
             "Command": "RegisterAccount",
             "Payload": {
                 "DiscordUsername": "testuser#1234",
-                "UbisoftAccountId": "550e8400-e29b-41d4-a716-446655440001",
+                "TmAccountId": "550e8400-e29b-41d4-a716-446655440001",
             },
         }
 
@@ -71,7 +71,7 @@ class TestRegistrationRequests(unittest.TestCase):
             "User": "550e8400-e29b-41d4-a716-446655440000",
             "Version": "1.0.0",
             "Command": "CheckRegistration",
-            "Payload": {"UbisoftAccountId": "550e8400-e29b-41d4-a716-446655440001"},
+            "Payload": {"TmAccountId": "550e8400-e29b-41d4-a716-446655440001"},
         }
 
         parsed_request = self.request_parser.from_buffer(json.dumps(check_request))


### PR DESCRIPTION
Implementation to handle party invites/accepts through the plugin
- Clean up plugin event bus
- Add party events to mm event bus
- Separate party system add/remove from discord logic
- Add handlers for party requests from plugins
- Add new "initialize" request to handle populating plugins with initial state on first request
- Adjust responses so plugins remain connected by default instead of closing connections

**Contains breaking changes. Do not deploy until new plugin version is approved**