### PR TITLE
fix: None check on primary leaderboard for sending Match Ready to plugins

### DIFF
--- a/lib/mm-bot/src/cogs/queue_view_builder.py
+++ b/lib/mm-bot/src/cogs/queue_view_builder.py
@@ -215,7 +215,7 @@ class QueueViewBuilder(commands.Cog):
             value = f"Channel ID: {queue.channel_id}\n"
             value += f"Display Name: {display_name}\n"
             value += f"Campaign Link: {campaign_link}\n"
-            value += f"Primary Leaderboard: {queue.get_primary_leaderboard()}"
+            value += f"Primary Leaderboard: {queue.get_primary_leaderboard()}\n"
             value += f"Active: {active}\n"
 
             embed.add_field(

--- a/lib/mm-bot/src/plugin/command_builder.py
+++ b/lib/mm-bot/src/plugin/command_builder.py
@@ -55,25 +55,30 @@ class CommandBuilder:
         if match.match_queue.type.is_2v2():
             team_id = 0
             for team in match.teams():
-                player_a_elo = self._ddb_manager.get_or_create_player_elo(
-                    team.player_a.tm_account_id, leaderboard_id
-                )
-                player_b_elo = self._ddb_manager.get_or_create_player_elo(
-                    team.player_b.tm_account_id, leaderboard_id
-                )
-                command.add_player(
-                    team.player_a.tm_account_id, player_a_elo.elo, team_id
-                )
-                command.add_player(
-                    team.player_b.tm_account_id, player_b_elo.elo, team_id
-                )
+                if leaderboard_id:
+                    player_a_elo = self._ddb_manager.get_or_create_player_elo(
+                        team.player_a.tm_account_id, leaderboard_id
+                    ).elo
+                    player_b_elo = self._ddb_manager.get_or_create_player_elo(
+                        team.player_b.tm_account_id, leaderboard_id
+                    ).elo
+                else:
+                    player_a_elo = 0
+                    player_b_elo = 0
+
+                command.add_player(team.player_a.tm_account_id, player_a_elo, team_id)
+                command.add_player(team.player_b.tm_account_id, player_b_elo, team_id)
                 team_id += 1
         else:
             for player in match.participants():
-                player_elo = self._ddb_manager.get_or_create_player_elo(
-                    player.tm_account_id, leaderboard_id
-                )
-                command.add_player(player.tm_account_id, player_elo.elo)
+                if leaderboard_id:
+                    player_elo = self._ddb_manager.get_or_create_player_elo(
+                        player.tm_account_id, leaderboard_id
+                    ).elo
+                else:
+                    player_elo = 0
+
+                command.add_player(player.tm_account_id, player_elo)
 
         return command
 

--- a/lib/mm-bot/src/plugin/event_queues/base_event_queue.py
+++ b/lib/mm-bot/src/plugin/event_queues/base_event_queue.py
@@ -5,6 +5,7 @@ from cogs.matchmaking_manager_v2 import get_matchmaking_manager_v2
 from matchmaking.mm_event_bus import MatchmakingManagerEventBus
 from plugin.command_builder import CommandBuilder
 from plugin.connection import PluginConnection
+from plugin.responses.base_response import BaseResponse
 
 
 class BaseEventQueue:
@@ -14,14 +15,15 @@ class BaseEventQueue:
         self.mm_manager = get_matchmaking_manager_v2()
         self.mm_event_bus = MatchmakingManagerEventBus()
 
-    async def send_command(self, client: PluginConnection, response):
+    async def send_command(self, client: PluginConnection, response: BaseResponse):
         try:
             if client:
                 await client.send_command(response)
                 return True
-        except Exception as e:
+        except Exception:
+            logging.info("Failed command data: %s", response.payload())
             logging.exception(
-                f"Failed trying to sending command to user: {client.identifier()}", e
+                "Failed trying to sending command to user: %s", client.identifier()
             )
         return False
 

--- a/lib/mm-bot/src/plugin/event_queues/match_ready.py
+++ b/lib/mm-bot/src/plugin/event_queues/match_ready.py
@@ -19,6 +19,9 @@ class MatchReadyEventQueue(BaseEventQueue):
             for player in event.participants():
                 client = connections.get(player.tm_account_id)
                 if client:
+                    logging.info(
+                        "Sending match ready command to %s", client.identifier()
+                    )
                     await self.send_command(client, command)
 
             self.mm_event_bus.add_queue_update(event.match_queue.queue_id)

--- a/lib/mm-bot/src/plugin/response_builder.py
+++ b/lib/mm-bot/src/plugin/response_builder.py
@@ -132,13 +132,11 @@ class ResponseBuilder:
                 if current_queue is not None:
                     for player in player_party:
                         player_elo = 0
-                        try:
+                        if current_queue.queue.get_primary_leaderboard():
                             player_elo = self._ddb_manager.get_or_create_player_elo(
                                 player.tm_account_id,
                                 current_queue.queue.get_primary_leaderboard(),
                             ).elo
-                        except Exception:
-                            pass
 
                         response.add_party_member(player.tm_account_id, player_elo)
                 else:
@@ -162,12 +160,10 @@ class ResponseBuilder:
         )
         for active_queue in sorted_queues:
             player_elo = 0
-            try:
+            if active_queue.queue.get_primary_leaderboard():
                 player_elo = self._ddb_manager.get_or_create_player_elo(
                     profile.tm_account_id, active_queue.queue.get_primary_leaderboard()
                 ).elo
-            except Exception:
-                pass
 
             response.add_queue(
                 active_queue.queue.queue_id,
@@ -186,12 +182,10 @@ class ResponseBuilder:
             )
 
         my_elo = 0
-        try:
+        if queue.queue.get_primary_leaderboard():
             my_elo = self._ddb_manager.get_or_create_player_elo(
                 profile.tm_account_id, queue.queue.get_primary_leaderboard()
             ).elo
-        except Exception:
-            pass
 
         response = JoinQueueResponse()
         response.add_queue(queue.queue.queue_id, queue.queue.display_name, my_elo)
@@ -226,12 +220,10 @@ class ResponseBuilder:
 
             for player in player_party:
                 player_elo = 0
-                try:
+                if queue.queue.get_primary_leaderboard():
                     player_elo = self._ddb_manager.get_or_create_player_elo(
                         player.tm_account_id, queue.queue.get_primary_leaderboard()
                     ).elo
-                except Exception:
-                    pass
 
                 response.add_party_member(player.tm_account_id, player_elo)
         else:


### PR DESCRIPTION
Add check for leaderboard id on a queue when trying to build the Match Ready command for plugins. This check missing caused plugins to never receive the match information in game.